### PR TITLE
i18n: Traduzir texto da UI para Português do Brasil

### DIFF
--- a/src/app/(app)/calendar/page.tsx
+++ b/src/app/(app)/calendar/page.tsx
@@ -14,7 +14,7 @@ export default function CalendarPage() {
     // Placeholder for Google Calendar OAuth flow
     setIsSynced(true); 
     // In a real app, show a toast or confirmation
-    alert("Google Calendar sync initiated (mock).");
+    alert("Sincronização com Google Agenda iniciada (simulado).");
   };
   
   return (
@@ -23,28 +23,28 @@ export default function CalendarPage() {
         <CardHeader>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <CardTitle className="font-headline text-3xl">My Calendar</CardTitle>
+              <CardTitle className="font-headline text-3xl">Meu Calendário</CardTitle>
               <CardDescription className="text-lg text-muted-foreground">
-                Manage your appointments and sync with Google Calendar.
+                Gerencie seus agendamentos e sincronize com o Google Agenda.
               </CardDescription>
             </div>
             <Button className="mt-4 sm:mt-0">
-              <PlusCircle className="mr-2 h-5 w-5" /> New Appointment
+              <PlusCircle className="mr-2 h-5 w-5" /> Novo Agendamento
             </Button>
           </div>
         </CardHeader>
         <CardContent>
           {!isSynced && (
             <div className="mb-6 p-4 bg-accent/20 border border-accent rounded-lg text-center">
-              <p className="text-accent-foreground mb-2">Your Google Calendar is not yet synced.</p>
+              <p className="text-accent-foreground mb-2">Seu Google Agenda ainda não está sincronizado.</p>
               <Button onClick={handleSyncGoogleCalendar} variant="default">
-                <ExternalLink className="mr-2 h-4 w-4" /> Sync with Google Calendar
+                <ExternalLink className="mr-2 h-4 w-4" /> Sincronizar com Google Agenda
               </Button>
             </div>
           )}
           {isSynced && (
              <div className="mb-6 p-4 bg-green-100 border border-green-600 text-green-700 rounded-lg text-center">
-              <p>Successfully synced with Google Calendar (mock).</p>
+              <p>Sincronizado com sucesso com o Google Agenda (simulado).</p>
             </div>
           )}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -68,15 +68,15 @@ export default function CalendarPage() {
               <Card className="shadow-md">
                 <CardHeader>
                   <CardTitle className="font-headline text-xl">
-                    Appointments for {date ? date.toLocaleDateString() : 'selected date'}
+                    Agendamentos para {date ? date.toLocaleDateString('pt-BR') : 'data selecionada'}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   {/* Placeholder for appointments list */}
                   <ul className="space-y-2">
-                    <li className="p-3 bg-secondary/50 rounded-md">10:00 AM - John Doe</li>
-                    <li className="p-3 bg-secondary/50 rounded-md">02:30 PM - Jane Smith</li>
-                    <li classNamep-3 text-muted-foreground>No more appointments today.</li>
+                    <li className="p-3 bg-secondary/50 rounded-md">10:00 - João Ninguém</li>
+                    <li className="p-3 bg-secondary/50 rounded-md">14:30 - Joana Silva</li>
+                    <li classNamep-3 text-muted-foreground>Não há mais agendamentos para hoje.</li>
                   </ul>
                 </CardContent>
               </Card>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,61 +9,61 @@ export default function DashboardPage() {
     <div className="space-y-8">
       <Card className="shadow-lg">
         <CardHeader>
-          <CardTitle className="font-headline text-3xl">Welcome to AgendaWise!</CardTitle>
+          <CardTitle className="font-headline text-3xl">Bem-vindo(a) ao AgendaWise!</CardTitle>
           <CardDescription className="text-lg text-muted-foreground">
-            Your central hub for managing appointments, patients, and session insights.
+            Seu hub central para gerenciar agendamentos, pacientes e insights de sessões.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <p>Here you can quickly access your upcoming appointments, recent patient activity, and utilize AI-powered tools to enhance your practice.</p>
+          <p>Aqui você pode acessar rapidamente seus próximos agendamentos, atividade recente de pacientes e utilizar ferramentas com IA para aprimorar sua prática.</p>
         </CardContent>
       </Card>
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         <Card className="shadow-md hover:shadow-lg transition-shadow">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="font-headline text-xl">Upcoming Appointments</CardTitle>
+            <CardTitle className="font-headline text-xl">Próximos Agendamentos</CardTitle>
             <CalendarCheck className="h-6 w-6 text-primary" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">3</div>
             <p className="text-xs text-muted-foreground">
-              scheduled for this week
+              agendados para esta semana
             </p>
             <Button asChild variant="outline" className="mt-4">
-              <Link href="/calendar">View Calendar</Link>
+              <Link href="/calendar">Ver Calendário</Link>
             </Button>
           </CardContent>
         </Card>
 
         <Card className="shadow-md hover:shadow-lg transition-shadow">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="font-headline text-xl">Active Patients</CardTitle>
+            <CardTitle className="font-headline text-xl">Pacientes Ativos</CardTitle>
             <Users className="h-6 w-6 text-primary" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">12</div>
             <p className="text-xs text-muted-foreground">
-              currently in your roster
+              atualmente na sua lista
             </p>
             <Button asChild variant="outline" className="mt-4">
-              <Link href="/patients">Manage Patients</Link>
+              <Link href="/patients">Gerenciar Pacientes</Link>
             </Button>
           </CardContent>
         </Card>
         
         <Card className="shadow-md hover:shadow-lg transition-shadow">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="font-headline text-xl">AI Note Insights</CardTitle>
+            <CardTitle className="font-headline text-xl">Insights de Anotações com IA</CardTitle>
             <Brain className="h-6 w-6 text-primary" />
           </CardHeader>
           <CardContent>
              <p className="text-sm text-muted-foreground mb-2">
-              Analyze session notes for keywords, themes, and insights.
+              Analise anotações de sessão por palavras-chave, temas e insights.
             </p>
             <Button asChild variant="outline" className="mt-4">
                {/* This might link to a specific patient's notes or a general notes section */}
-              <Link href="/patients">Go to Patient Notes</Link>
+              <Link href="/patients">Ir para Anotações do Paciente</Link>
             </Button>
           </CardContent>
         </Card>
@@ -71,22 +71,22 @@ export default function DashboardPage() {
 
       <Card className="shadow-lg">
         <CardHeader>
-          <CardTitle className="font-headline text-2xl">Quick Actions</CardTitle>
+          <CardTitle className="font-headline text-2xl">Ações Rápidas</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-wrap gap-4">
           <Button asChild size="lg">
             <Link href="/calendar/new">
-              <CalendarCheck className="mr-2 h-5 w-5" /> New Appointment
+              <CalendarCheck className="mr-2 h-5 w-5" /> Novo Agendamento
             </Link>
           </Button>
           <Button asChild variant="secondary" size="lg">
             <Link href="/patients?action=new">
-              <Users className="mr-2 h-5 w-5" /> Add New Patient
+              <Users className="mr-2 h-5 w-5" /> Adicionar Novo Paciente
             </Link>
           </Button>
            <Button asChild variant="secondary" size="lg">
             <Link href="/patients">
-              <FileText className="mr-2 h-5 w-5" /> View Session Notes
+              <FileText className="mr-2 h-5 w-5" /> Ver Anotações da Sessão
             </Link>
           </Button>
         </CardContent>
@@ -96,17 +96,17 @@ export default function DashboardPage() {
         <div className="flex flex-col md:flex-row items-center gap-6">
           <Image 
             src="https://placehold.co/600x400.png" 
-            alt="Calm workspace" 
+            alt="Ambiente de trabalho calmo"
             width={300} 
             height={200} 
             className="rounded-lg shadow-md"
             data-ai-hint="workspace calm" 
           />
           <div>
-            <h3 className="font-headline text-xl text-primary mb-2">Stay Organized, Stay Mindful</h3>
+            <h3 className="font-headline text-xl text-primary mb-2">Mantenha-se Organizado, Mantenha-se Atento</h3>
             <p className="text-muted-foreground">
-              AgendaWise is designed to provide a calm and focused environment for your practice. 
-              Leverage powerful tools while maintaining a sense of tranquility and control.
+              O AgendaWise foi projetado para fornecer um ambiente calmo e focado para sua prática.
+              Utilize ferramentas poderosas enquanto mantém uma sensação de tranquilidade e controle.
             </p>
           </div>
         </div>

--- a/src/app/(app)/patients/[patientId]/edit/page.tsx
+++ b/src/app/(app)/patients/[patientId]/edit/page.tsx
@@ -66,8 +66,8 @@ export default function EditPatientPage() {
     // Mock form submission
     console.log("Updated patient data:", formData);
     toast({
-      title: "Patient Updated (Mock)",
-      description: `${formData.name}'s profile has been successfully updated.`,
+      title: "Paciente Atualizado (Simulado)",
+      description: `O perfil de ${formData.name} foi atualizado com sucesso.`,
       className: "bg-primary text-primary-foreground",
     });
     router.push(`/patients/${patientId}`); 
@@ -77,7 +77,7 @@ export default function EditPatientPage() {
     return (
       <div className="flex justify-center items-center min-h-[calc(100vh-theme(spacing.16))]"> 
         <Save className="h-12 w-12 animate-spin text-primary" /> 
-        <p className="ml-4 text-lg text-muted-foreground">Loading patient data...</p>
+        <p className="ml-4 text-lg text-muted-foreground">Carregando dados do paciente...</p>
       </div>
     );
   }
@@ -91,52 +91,52 @@ export default function EditPatientPage() {
           </Link>
         </Button>
         <div>
-          <h1 className="font-headline text-3xl">Edit Patient Profile</h1>
-          <p className="text-muted-foreground">Update the details for {formData.name}.</p>
+          <h1 className="font-headline text-3xl">Editar Perfil do Paciente</h1>
+          <p className="text-muted-foreground">Atualize os detalhes para {formData.name}.</p>
         </div>
       </div>
       
       <Card className="shadow-lg">
         <CardHeader>
           <CardTitle className="font-headline text-2xl flex items-center">
-            <UserCog className="mr-3 h-7 w-7 text-primary" /> Edit Patient Information
+            <UserCog className="mr-3 h-7 w-7 text-primary" /> Editar Informações do Paciente
           </CardTitle>
           <CardDescription>
-            Modify the fields below and save your changes.
+            Modifique os campos abaixo e salve suas alterações.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <Label htmlFor="name">Full Name</Label>
-                <Input id="name" value={formData.name} onChange={handleChange} placeholder="e.g., John Doe" required />
+                <Label htmlFor="name">Nome Completo</Label>
+                <Input id="name" value={formData.name} onChange={handleChange} placeholder="Ex: João Ninguém" required />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="dob">Date of Birth</Label>
+                <Label htmlFor="dob">Data de Nascimento</Label>
                 <Input id="dob" type="date" value={formData.dob} onChange={handleChange} required />
               </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <Label htmlFor="email">Email Address</Label>
-                <Input id="email" type="email" value={formData.email} onChange={handleChange} placeholder="e.g., john.doe@example.com" />
+                <Label htmlFor="email">Endereço de E-mail</Label>
+                <Input id="email" type="email" value={formData.email} onChange={handleChange} placeholder="Ex: joao.ninguem@example.com" />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="phone">Phone Number</Label>
-                <Input id="phone" type="tel" value={formData.phone} onChange={handleChange} placeholder="e.g., +1-555-123-4567" />
+                <Label htmlFor="phone">Número de Telefone</Label>
+                <Input id="phone" type="tel" value={formData.phone} onChange={handleChange} placeholder="Ex: +55 (XX) XXXXX-XXXX" />
               </div>
             </div>
             
             <div className="space-y-2">
-              <Label htmlFor="address">Address</Label>
-              <Textarea id="address" value={formData.address} onChange={handleChange} placeholder="e.g., 123 Wellness St, Tranquility City, CA 90210" className="min-h-[100px]" />
+              <Label htmlFor="address">Endereço</Label>
+              <Textarea id="address" value={formData.address} onChange={handleChange} placeholder="Ex: Rua do Bem-Estar, 123, Cidade da Tranquilidade, UF 12345-678" className="min-h-[100px]" />
             </div>
 
             <div className="flex justify-end pt-4">
               <Button type="submit" size="lg">
-                <Save className="mr-2 h-5 w-5" /> Update Patient
+                <Save className="mr-2 h-5 w-5" /> Atualizar Paciente
               </Button>
             </div>
           </form>

--- a/src/app/(app)/patients/[patientId]/page.tsx
+++ b/src/app/(app)/patients/[patientId]/page.tsx
@@ -54,13 +54,13 @@ const mockPatient: Patient = {
 };
 
 const mockNotes: SessionNote[] = [
-  { id: 'n1', date: '2024-07-15', content: 'Patient reported feeling anxious about work presentation. Discussed coping mechanisms and breathing exercises. Showed improvement in mood by end of session.' },
-  { id: 'n2', date: '2024-07-08', content: 'Follow-up on family stressors. Patient is implementing communication strategies discussed previously. Still some tension but progress is noted.' },
+  { id: 'n1', date: '2024-07-15', content: 'Paciente relatou sentir-se ansioso com a apresentação no trabalho. Discutimos mecanismos de enfrentamento e exercícios de respiração. Mostrou melhora no humor ao final da sessão.' },
+  { id: 'n2', date: '2024-07-08', content: 'Acompanhamento sobre estressores familiares. Paciente está implementando estratégias de comunicação discutidas anteriormente. Ainda há alguma tensão, mas nota-se progresso.' },
 ];
 
 const mockDocuments: Document[] = [
-  { id: 'd1', name: 'Intake Form.pdf', uploadDate: '2023-01-10', url: '#' },
-  { id: 'd2', name: 'Referral Letter.docx', uploadDate: '2023-02-20', url: '#' },
+  { id: 'd1', name: 'Formulário de Admissão.pdf', uploadDate: '2023-01-10', url: '#' },
+  { id: 'd2', name: 'Carta de Encaminhamento.docx', uploadDate: '2023-02-20', url: '#' },
 ];
 
 
@@ -85,16 +85,16 @@ export default function PatientDetailPage() {
         prevNotes.map(n => n.id === note.id ? { ...n, insights } : n)
       );
       toast({
-        title: "Analysis Complete",
-        description: "Session note insights generated successfully.",
+        title: "Análise Concluída",
+        description: "Insights da anotação de sessão gerados com sucesso.",
         variant: "default",
         className: "bg-primary text-primary-foreground"
       });
     } catch (error) {
-      console.error("Error analyzing note:", error);
+      console.error("Erro ao analisar anotação:", error);
       toast({
-        title: "Analysis Failed",
-        description: "Could not generate insights for the session note.",
+        title: "Falha na Análise",
+        description: "Não foi possível gerar insights para a anotação da sessão.",
         variant: "destructive",
       });
     } finally {
@@ -104,7 +104,7 @@ export default function PatientDetailPage() {
 
   const handleAddNote = () => {
     if (!newNoteContent.trim()) {
-      toast({ title: "Empty Note", description: "Cannot save an empty note.", variant: "destructive" });
+      toast({ title: "Anotação Vazia", description: "Não é possível salvar uma anotação vazia.", variant: "destructive" });
       return;
     }
     const newNote: SessionNote = {
@@ -114,7 +114,7 @@ export default function PatientDetailPage() {
     };
     setSessionNotes([newNote, ...sessionNotes]);
     setNewNoteContent('');
-    toast({ title: "Note Saved", description: "New session note added successfully.", className: "bg-primary text-primary-foreground" });
+    toast({ title: "Anotação Salva", description: "Nova anotação de sessão adicionada com sucesso.", className: "bg-primary text-primary-foreground" });
   };
   
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -128,7 +128,7 @@ export default function PatientDetailPage() {
         url: '#', // In real app, use signed URL from GCS
       };
       setDocuments([newDoc, ...documents]);
-      toast({ title: "File Uploaded", description: `${file.name} has been added. (Mock)`, className: "bg-primary text-primary-foreground" });
+      toast({ title: "Arquivo Carregado", description: `${file.name} foi adicionado. (Simulado)`, className: "bg-primary text-primary-foreground" });
     }
   };
 
@@ -142,11 +142,11 @@ export default function PatientDetailPage() {
           </Avatar>
           <div>
             <CardTitle className="font-headline text-3xl">{patient.name}</CardTitle>
-            <CardDescription className="text-lg text-muted-foreground">Patient ID: {patient.id}</CardDescription>
+            <CardDescription className="text-lg text-muted-foreground">ID do Paciente: {patient.id}</CardDescription>
             <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground mt-2">
               <span className="flex items-center"><Mail className="h-4 w-4 mr-1 text-primary" /> {patient.email}</span>
               <span className="flex items-center"><Phone className="h-4 w-4 mr-1 text-primary" /> {patient.phone}</span>
-              <span className="flex items-center"><CalendarDays className="h-4 w-4 mr-1 text-primary" /> Joined: {patient.joinedDate}</span>
+              <span className="flex items-center"><CalendarDays className="h-4 w-4 mr-1 text-primary" /> Entrou em: {new Date(patient.joinedDate).toLocaleDateString('pt-BR')}</span>
             </div>
           </div>
         </CardHeader>
@@ -154,25 +154,25 @@ export default function PatientDetailPage() {
 
       <Tabs defaultValue="profile" className="w-full">
         <TabsList className="grid w-full grid-cols-1 sm:grid-cols-3 mb-6">
-          <TabsTrigger value="profile" className="py-3"><User className="mr-2 h-5 w-5" />Profile Details</TabsTrigger>
-          <TabsTrigger value="notes" className="py-3"><FileText className="mr-2 h-5 w-5" />Session Notes</TabsTrigger>
-          <TabsTrigger value="documents" className="py-3"><UploadCloud className="mr-2 h-5 w-5" />Documents</TabsTrigger>
+          <TabsTrigger value="profile" className="py-3"><User className="mr-2 h-5 w-5" />Detalhes do Perfil</TabsTrigger>
+          <TabsTrigger value="notes" className="py-3"><FileText className="mr-2 h-5 w-5" />Anotações da Sessão</TabsTrigger>
+          <TabsTrigger value="documents" className="py-3"><UploadCloud className="mr-2 h-5 w-5" />Documentos</TabsTrigger>
         </TabsList>
 
         <TabsContent value="profile">
           <Card className="shadow-md">
             <CardHeader>
-              <CardTitle className="font-headline text-2xl">Patient Information</CardTitle>
+              <CardTitle className="font-headline text-2xl">Informações do Paciente</CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div><Label htmlFor="name">Full Name</Label><Input id="name" value={patient.name} readOnly /></div>
-                <div><Label htmlFor="dob">Date of Birth</Label><Input id="dob" value={patient.dob} readOnly /></div>
-                <div><Label htmlFor="email">Email Address</Label><Input id="email" type="email" value={patient.email} readOnly /></div>
-                <div><Label htmlFor="phone">Phone Number</Label><Input id="phone" type="tel" value={patient.phone} readOnly /></div>
-                <div className="md:col-span-2"><Label htmlFor="address">Address</Label><Textarea id="address" value={patient.address} readOnly className="h-24" /></div>
+                <div><Label htmlFor="name">Nome Completo</Label><Input id="name" value={patient.name} readOnly /></div>
+                <div><Label htmlFor="dob">Data de Nascimento</Label><Input id="dob" value={new Date(patient.dob).toLocaleDateString('pt-BR')} readOnly /></div>
+                <div><Label htmlFor="email">Endereço de E-mail</Label><Input id="email" type="email" value={patient.email} readOnly /></div>
+                <div><Label htmlFor="phone">Número de Telefone</Label><Input id="phone" type="tel" value={patient.phone} readOnly /></div>
+                <div className="md:col-span-2"><Label htmlFor="address">Endereço</Label><Textarea id="address" value={patient.address} readOnly className="h-24" /></div>
               </div>
-              <Button variant="outline"><User className="mr-2 h-4 w-4" /> Edit Profile (Placeholder)</Button>
+              <Button variant="outline"><User className="mr-2 h-4 w-4" /> Editar Perfil (Espaço reservado)</Button>
             </CardContent>
           </Card>
         </TabsContent>
@@ -180,22 +180,22 @@ export default function PatientDetailPage() {
         <TabsContent value="notes">
           <Card className="shadow-md">
             <CardHeader>
-              <CardTitle className="font-headline text-2xl">Session Notes</CardTitle>
+              <CardTitle className="font-headline text-2xl">Anotações da Sessão</CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="space-y-2">
-                <Label htmlFor="new-note" className="text-lg">Add New Note</Label>
+                <Label htmlFor="new-note" className="text-lg">Adicionar Nova Anotação</Label>
                 <Textarea
                   id="new-note"
                   value={newNoteContent}
                   onChange={(e) => setNewNoteContent(e.target.value)}
-                  placeholder={`Record notes for session on ${new Date().toLocaleDateString()}...`}
+                  placeholder={`Registre anotações para a sessão de ${new Date().toLocaleDateString('pt-BR')}...`}
                   className="min-h-[120px]"
                 />
-                <Button onClick={handleAddNote}><Save className="mr-2 h-4 w-4"/>Save Note</Button>
+                <Button onClick={handleAddNote}><Save className="mr-2 h-4 w-4"/>Salvar Anotação</Button>
               </div>
               <hr/>
-              <h3 className="font-headline text-xl mt-4">Previous Notes</h3>
+              <h3 className="font-headline text-xl mt-4">Anotações Anteriores</h3>
               {sessionNotes.length > 0 ? (
                 <ScrollArea className="h-[400px] pr-4">
                   <div className="space-y-4">
@@ -203,7 +203,7 @@ export default function PatientDetailPage() {
                     <Card key={note.id} className="bg-background/70">
                       <CardHeader>
                         <div className="flex justify-between items-center">
-                          <CardTitle className="text-md font-semibold">Session: {note.date}</CardTitle>
+                          <CardTitle className="text-md font-semibold">Sessão: {new Date(note.date).toLocaleDateString('pt-BR')}</CardTitle>
                           <Button 
                             variant="outline" 
                             size="sm" 
@@ -211,7 +211,7 @@ export default function PatientDetailPage() {
                             disabled={analyzingNoteId === note.id}
                           >
                             {analyzingNoteId === note.id ? <Wand2 className="mr-2 h-4 w-4 animate-spin" /> : <Brain className="mr-2 h-4 w-4" />}
-                            {analyzingNoteId === note.id ? "Analyzing..." : "AI Insights"}
+                            {analyzingNoteId === note.id ? "Analisando..." : "Insights de IA"}
                           </Button>
                         </div>
                       </CardHeader>
@@ -219,10 +219,10 @@ export default function PatientDetailPage() {
                         <p className="whitespace-pre-wrap text-sm">{note.content}</p>
                         {note.insights && (
                           <div className="mt-4 p-3 border rounded-md bg-secondary/30 space-y-2">
-                            <h4 className="font-semibold text-sm text-primary">AI Generated Insights:</h4>
-                            <div><strong>Keywords:</strong> <span className="text-xs">{note.insights.keywords.join(', ')}</span></div>
-                            <div><strong>Themes:</strong> <span className="text-xs">{note.insights.themes.join(', ')}</span></div>
-                            <div><strong>Potential Insights:</strong>
+                            <h4 className="font-semibold text-sm text-primary">Insights Gerados por IA:</h4>
+                            <div><strong>Palavras-chave:</strong> <span className="text-xs">{note.insights.keywords.join(', ')}</span></div>
+                            <div><strong>Temas:</strong> <span className="text-xs">{note.insights.themes.join(', ')}</span></div>
+                            <div><strong>Insights Potenciais:</strong>
                               <ul className="list-disc list-inside text-xs">
                                 {note.insights.insights.map((insight, i) => <li key={i}>{insight}</li>)}
                               </ul>
@@ -235,7 +235,7 @@ export default function PatientDetailPage() {
                   </div>
                 </ScrollArea>
               ) : (
-                <p className="text-muted-foreground">No session notes recorded yet.</p>
+                <p className="text-muted-foreground">Nenhuma anotação de sessão registrada ainda.</p>
               )}
             </CardContent>
           </Card>
@@ -244,37 +244,37 @@ export default function PatientDetailPage() {
         <TabsContent value="documents">
           <Card className="shadow-md">
             <CardHeader>
-              <CardTitle className="font-headline text-2xl">Patient Documents</CardTitle>
+              <CardTitle className="font-headline text-2xl">Documentos do Paciente</CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
               <div>
-                <Label htmlFor="file-upload" className="block text-lg mb-2">Upload New Document</Label>
+                <Label htmlFor="file-upload" className="block text-lg mb-2">Carregar Novo Documento</Label>
                 <div className="flex items-center space-x-2">
                   <Input id="file-upload" type="file" onChange={handleFileUpload} className="w-auto" />
                   {/* <Button><UploadCloud className="mr-2 h-4 w-4" /> Upload (Placeholder)</Button> */}
                 </div>
-                <p className="text-xs text-muted-foreground mt-1">Max file size: 5MB. Allowed types: PDF, DOCX, JPG, PNG.</p>
+                <p className="text-xs text-muted-foreground mt-1">Tamanho máximo do arquivo: 5MB. Tipos permitidos: PDF, DOCX, JPG, PNG.</p>
               </div>
                <hr/>
-              <h3 className="font-headline text-xl mt-4">Uploaded Documents</h3>
+              <h3 className="font-headline text-xl mt-4">Documentos Carregados</h3>
               {documents.length > 0 ? (
                 <ul className="space-y-3">
                   {documents.map(doc => (
                     <li key={doc.id} className="flex items-center justify-between p-3 border rounded-md hover:bg-secondary/20">
                       <div>
                         <a href={doc.url} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline font-medium">{doc.name}</a>
-                        <p className="text-xs text-muted-foreground">Uploaded: {doc.uploadDate}</p>
+                        <p className="text-xs text-muted-foreground">Carregado em: {new Date(doc.uploadDate).toLocaleDateString('pt-BR')}</p>
                       </div>
                       <Button variant="outline" size="sm" asChild>
-                        <a href={doc.url} download={doc.name} target="_blank">Download</a>
+                        <a href={doc.url} download={doc.name} target="_blank">Baixar</a>
                       </Button>
                     </li>
                   ))}
                 </ul>
               ) : (
                  <div className="text-center py-6">
-                  <Image src="https://placehold.co/200x150.png" alt="No documents" width={150} height={100} className="mx-auto rounded-md mb-2" data-ai-hint="empty folder document" />
-                  <p className="text-muted-foreground">No documents uploaded for this patient yet.</p>
+                  <Image src="https://placehold.co/200x150.png" alt="Nenhum documento" width={150} height={100} className="mx-auto rounded-md mb-2" data-ai-hint="empty folder document" />
+                  <p className="text-muted-foreground">Nenhum documento carregado para este paciente ainda.</p>
                 </div>
               )}
             </CardContent>

--- a/src/app/(app)/patients/new/page.tsx
+++ b/src/app/(app)/patients/new/page.tsx
@@ -32,8 +32,8 @@ export default function NewPatientPage() {
     // Mock form submission
     console.log("New patient data:", formData);
     toast({
-      title: "Patient Added (Mock)",
-      description: `${formData.name} has been successfully added to your directory.`,
+      title: "Paciente Adicionado (Simulado)",
+      description: `${formData.name} foi adicionado(a) com sucesso ao seu diretório.`,
       className: "bg-primary text-primary-foreground",
     });
     // Redirect to patients list or the new patient's detail page
@@ -49,52 +49,52 @@ export default function NewPatientPage() {
           </Link>
         </Button>
         <div>
-          <h1 className="font-headline text-3xl">Add New Patient</h1>
-          <p className="text-muted-foreground">Enter the details for the new patient profile.</p>
+          <h1 className="font-headline text-3xl">Adicionar Novo Paciente</h1>
+          <p className="text-muted-foreground">Insira os detalhes para o novo perfil do paciente.</p>
         </div>
       </div>
       
       <Card className="shadow-lg">
         <CardHeader>
           <CardTitle className="font-headline text-2xl flex items-center">
-            <UserPlus className="mr-3 h-7 w-7 text-primary" /> Patient Details
+            <UserPlus className="mr-3 h-7 w-7 text-primary" /> Detalhes do Paciente
           </CardTitle>
           <CardDescription>
-            Please fill in all required fields accurately.
+            Por favor, preencha todos os campos obrigatórios com precisão.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <Label htmlFor="name">Full Name</Label>
-                <Input id="name" value={formData.name} onChange={handleChange} placeholder="e.g., John Doe" required />
+                <Label htmlFor="name">Nome Completo</Label>
+                <Input id="name" value={formData.name} onChange={handleChange} placeholder="Ex: João Ninguém" required />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="dob">Date of Birth</Label>
+                <Label htmlFor="dob">Data de Nascimento</Label>
                 <Input id="dob" type="date" value={formData.dob} onChange={handleChange} required />
               </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
-                <Label htmlFor="email">Email Address</Label>
-                <Input id="email" type="email" value={formData.email} onChange={handleChange} placeholder="e.g., john.doe@example.com" />
+                <Label htmlFor="email">Endereço de E-mail</Label>
+                <Input id="email" type="email" value={formData.email} onChange={handleChange} placeholder="Ex: joao.ninguem@example.com" />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="phone">Phone Number</Label>
-                <Input id="phone" type="tel" value={formData.phone} onChange={handleChange} placeholder="e.g., +1-555-123-4567" />
+                <Label htmlFor="phone">Número de Telefone</Label>
+                <Input id="phone" type="tel" value={formData.phone} onChange={handleChange} placeholder="Ex: +55 (XX) XXXXX-XXXX" />
               </div>
             </div>
             
             <div className="space-y-2">
-              <Label htmlFor="address">Address</Label>
-              <Textarea id="address" value={formData.address} onChange={handleChange} placeholder="e.g., 123 Wellness St, Tranquility City, CA 90210" className="min-h-[100px]" />
+              <Label htmlFor="address">Endereço</Label>
+              <Textarea id="address" value={formData.address} onChange={handleChange} placeholder="Ex: Rua do Bem-Estar, 123, Cidade da Tranquilidade, UF 12345-678" className="min-h-[100px]" />
             </div>
 
             <div className="flex justify-end pt-4">
               <Button type="submit" size="lg">
-                <Save className="mr-2 h-5 w-5" /> Save Patient
+                <Save className="mr-2 h-5 w-5" /> Salvar Paciente
               </Button>
             </div>
           </form>

--- a/src/app/(app)/patients/page.tsx
+++ b/src/app/(app)/patients/page.tsx
@@ -54,14 +54,14 @@ export default function PatientsPage() {
         <CardHeader>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <CardTitle className="font-headline text-3xl">Patient Directory</CardTitle>
+              <CardTitle className="font-headline text-3xl">Diretório de Pacientes</CardTitle>
               <CardDescription className="text-lg text-muted-foreground">
-                Manage your patient profiles, notes, and documents.
+                Gerencie os perfis, anotações e documentos de seus pacientes.
               </CardDescription>
             </div>
             <Button asChild className="mt-4 sm:mt-0">
               <Link href="/patients/new">
-                <PlusCircle className="mr-2 h-5 w-5" /> Add New Patient
+                <PlusCircle className="mr-2 h-5 w-5" /> Adicionar Novo Paciente
               </Link>
             </Button>
           </div>
@@ -71,7 +71,7 @@ export default function PatientsPage() {
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" />
             <Input
               type="search"
-              placeholder="Search patients by name..."
+              placeholder="Pesquisar pacientes por nome..."
               className="pl-10 w-full md:w-1/2"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
@@ -89,12 +89,12 @@ export default function PatientsPage() {
                     </Avatar>
                     <div>
                       <CardTitle className="font-headline text-xl">{patient.name}</CardTitle>
-                      <CardDescription>Last Session: {patient.lastSession}</CardDescription>
+                      <CardDescription>Última Sessão: {new Date(patient.lastSession).toLocaleDateString('pt-BR')}</CardDescription>
                     </div>
                   </CardHeader>
                   <CardContent className="flex-grow">
                     {/* Placeholder for more patient info if needed */}
-                    <p className="text-sm text-muted-foreground">Click to view detailed profile, session notes, and documents.</p>
+                    <p className="text-sm text-muted-foreground">Clique para ver perfil detalhado, notas de sessão e documentos.</p>
                   </CardContent>
                   <CardFooter className="flex justify-between items-center pt-4 border-t">
                      <div className="flex gap-2">
@@ -111,15 +111,15 @@ export default function PatientsPage() {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                            <AlertDialogTitle>Você tem certeza?</AlertDialogTitle>
                             <AlertDialogDescription>
-                              This action cannot be undone. This will permanently delete the patient record for {patient.name}.
+                              Esta ação não pode ser desfeita. Isso excluirá permanentemente o registro do paciente {patient.name}.
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogCancel>Cancelar</AlertDialogCancel>
                             <AlertDialogAction onClick={() => handleDeletePatient(patient.id)}>
-                              Delete
+                              Excluir
                             </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>
@@ -127,7 +127,7 @@ export default function PatientsPage() {
                     </div>
                     <Button variant="default" size="sm" asChild>
                       <Link href={`/patients/${patient.id}`}>
-                        View Profile <ArrowRight className="ml-2 h-4 w-4" />
+                        Ver Perfil <ArrowRight className="ml-2 h-4 w-4" />
                       </Link>
                     </Button>
                   </CardFooter>
@@ -137,10 +137,10 @@ export default function PatientsPage() {
           ) : (
             <div className="text-center py-10">
               <Leaf className="mx-auto h-16 w-16 text-muted-foreground/50 mb-4" />
-              <p className="font-headline text-xl text-muted-foreground">No patients found.</p>
+              <p className="font-headline text-xl text-muted-foreground">Nenhum paciente encontrado.</p>
               <p className="text-sm text-muted-foreground">
-                {searchTerm ? "Try a different search term or " : ""}
-                <Link href="/patients/new" className="text-primary hover:underline">add a new patient</Link>.
+                {searchTerm ? "Tente um termo de pesquisa diferente ou " : ""}
+                <Link href="/patients/new" className="text-primary hover:underline">adicione um novo paciente</Link>.
               </p>
             </div>
           )}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -18,8 +18,8 @@ export default function SettingsPage() {
     // Placeholder for OAuth flow
     setIsCalendarSynced(!isCalendarSynced);
     toast({
-      title: `Google Calendar ${!isCalendarSynced ? 'Sync Enabled' : 'Sync Disabled'} (Mock)`,
-      description: `Your calendar integration status has been updated.`,
+      title: `Sincronização com Google Agenda ${!isCalendarSynced ? 'Ativada' : 'Desativada'} (Simulado)`,
+      description: `O status da integração do seu calendário foi atualizado.`,
       className: "bg-primary text-primary-foreground"
     });
   };
@@ -27,8 +27,8 @@ export default function SettingsPage() {
   const handleSaveChanges = () => {
     // Placeholder for saving settings
     toast({
-      title: "Settings Saved (Mock)",
-      description: "Your preferences have been updated successfully.",
+      title: "Configurações Salvas (Simulado)",
+      description: "Suas preferências foram atualizadas com sucesso.",
       className: "bg-primary text-primary-foreground"
     });
   };
@@ -37,43 +37,43 @@ export default function SettingsPage() {
     <div className="space-y-8 max-w-3xl mx-auto">
       <Card className="shadow-lg">
         <CardHeader>
-          <CardTitle className="font-headline text-3xl">Application Settings</CardTitle>
+          <CardTitle className="font-headline text-3xl">Configurações do Aplicativo</CardTitle>
           <CardDescription className="text-lg text-muted-foreground">
-            Customize your AgendaWise experience.
+            Personalize sua experiência AgendaWise.
           </CardDescription>
         </CardHeader>
       </Card>
 
       <Card>
         <CardHeader>
-          <CardTitle className="font-headline text-xl flex items-center"><CalendarCog className="mr-2 h-6 w-6 text-primary" />Calendar Integration</CardTitle>
+          <CardTitle className="font-headline text-xl flex items-center"><CalendarCog className="mr-2 h-6 w-6 text-primary" />Integração com Calendário</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex items-center justify-between p-4 border rounded-lg">
             <div>
-              <Label htmlFor="google-calendar-sync" className="text-base font-medium">Google Calendar Sync</Label>
+              <Label htmlFor="google-calendar-sync" className="text-base font-medium">Sincronização com Google Agenda</Label>
               <p className="text-sm text-muted-foreground">
-                {isCalendarSynced ? "Your calendar is currently synced." : "Connect your Google Calendar to manage appointments."}
+                {isCalendarSynced ? "Seu calendário está sincronizado no momento." : "Conecte seu Google Agenda para gerenciar agendamentos."}
               </p>
             </div>
             <Button onClick={handleGoogleCalendarSync} variant={isCalendarSynced ? "outline" : "default"}>
               <ExternalLink className="mr-2 h-4 w-4" />
-              {isCalendarSynced ? 'Disconnect Google Calendar' : 'Connect Google Calendar'}
+              {isCalendarSynced ? 'Desconectar Google Agenda' : 'Conectar Google Agenda'}
             </Button>
           </div>
           {isCalendarSynced && (
             <Card className="bg-secondary/30 p-4">
               <CardHeader className="p-0 pb-2">
-                <CardTitle className="text-md">Sync Options</CardTitle>
+                <CardTitle className="text-md">Opções de Sincronização</CardTitle>
               </CardHeader>
               <CardContent className="p-0 space-y-2">
                 <div className="flex items-center space-x-2">
                   <Switch id="two-way-sync" defaultChecked />
-                  <Label htmlFor="two-way-sync">Enable two-way sync</Label>
+                  <Label htmlFor="two-way-sync">Ativar sincronização bidirecional</Label>
                 </div>
                 <div className="flex items-center space-x-2">
                   <Switch id="private-events" />
-                  <Label htmlFor="private-events">Sync private events as "Busy"</Label>
+                  <Label htmlFor="private-events">Sincronizar eventos privados como "Ocupado"</Label>
                 </div>
               </CardContent>
             </Card>
@@ -83,16 +83,16 @@ export default function SettingsPage() {
       
       <Card>
         <CardHeader>
-          <CardTitle className="font-headline text-xl flex items-center"><UserCog className="mr-2 h-6 w-6 text-primary" />Account Preferences</CardTitle>
+          <CardTitle className="font-headline text-xl flex items-center"><UserCog className="mr-2 h-6 w-6 text-primary" />Preferências da Conta</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="space-y-2">
-            <Label htmlFor="profileName">Display Name</Label>
-            <Input id="profileName" defaultValue="AgendaWise User" />
+            <Label htmlFor="profileName">Nome de Exibição</Label>
+            <Input id="profileName" defaultValue="Usuário AgendaWise" />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="profileEmail">Email Address</Label>
-            <Input id="profileEmail" type="email" defaultValue="user@agendawise.com" />
+            <Label htmlFor="profileEmail">Endereço de E-mail</Label>
+            <Input id="profileEmail" type="email" defaultValue="usuario@agendawise.com" />
           </div>
            <div className="flex items-center space-x-2">
             <Switch
@@ -101,7 +101,7 @@ export default function SettingsPage() {
               onCheckedChange={setNotificationsEnabled}
             />
             <Label htmlFor="notifications-enabled" className="flex items-center">
-              <Bell className="mr-2 h-4 w-4" /> Enable Email Notifications
+              <Bell className="mr-2 h-4 w-4" /> Ativar Notificações por E-mail
             </Label>
           </div>
         </CardContent>
@@ -109,30 +109,30 @@ export default function SettingsPage() {
       
       <Card>
         <CardHeader>
-          <CardTitle className="font-headline text-xl flex items-center"><Palette className="mr-2 h-6 w-6 text-primary" />Appearance</CardTitle>
+          <CardTitle className="font-headline text-xl flex items-center"><Palette className="mr-2 h-6 w-6 text-primary" />Aparência</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
             <div className="flex items-center space-x-2">
                 <Switch id="dark-mode" disabled /> {/* Dark mode toggle could be implemented here */}
-                <Label htmlFor="dark-mode">Enable Dark Mode (Coming Soon)</Label>
+                <Label htmlFor="dark-mode">Ativar Modo Escuro (Em Breve)</Label>
             </div>
-            <p className="text-sm text-muted-foreground">Customize the look and feel of the application.</p>
+            <p className="text-sm text-muted-foreground">Personalize a aparência do aplicativo.</p>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader>
-          <CardTitle className="font-headline text-xl flex items-center"><ShieldCheck className="mr-2 h-6 w-6 text-primary" />Security & Privacy</CardTitle>
+          <CardTitle className="font-headline text-xl flex items-center"><ShieldCheck className="mr-2 h-6 w-6 text-primary" />Segurança e Privacidade</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-            <Button variant="outline">Change Password (Placeholder)</Button>
-            <Button variant="outline">Export My Data (Placeholder)</Button>
-            <p className="text-sm text-muted-foreground">Manage your account security and data privacy settings.</p>
+            <Button variant="outline">Alterar Senha (Espaço reservado)</Button>
+            <Button variant="outline">Exportar Meus Dados (Espaço reservado)</Button>
+            <p className="text-sm text-muted-foreground">Gerencie a segurança da sua conta e as configurações de privacidade de dados.</p>
         </CardContent>
       </Card>
 
       <div className="flex justify-end pt-4">
-        <Button size="lg" onClick={handleSaveChanges}>Save All Settings</Button>
+        <Button size="lg" onClick={handleSaveChanges}>Salvar Todas as Configurações</Button>
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,9 +33,9 @@ export default function LoginPage() {
             <Leaf className="h-12 w-12 text-primary" />
             <h1 className="font-headline text-4xl font-bold text-primary ml-2">AgendaWise</h1>
           </div>
-          <CardTitle className="font-headline text-2xl">Welcome Back</CardTitle>
+          <CardTitle className="font-headline text-2xl">Bem-vindo(a) de volta</CardTitle>
           <CardDescription className="text-muted-foreground">
-            Sign in to manage your appointments and patient notes.
+            Faça login para gerenciar seus agendamentos e notas de pacientes.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -43,10 +43,10 @@ export default function LoginPage() {
             {/* Modifique o onClick para usar signIn do next-auth */}
             <Button onClick={() => signIn('google')} className="w-full bg-primary hover:bg-primary/90 text-primary-foreground" size="lg">
               <svg className="mr-2 h-5 w-5" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="google" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 488 512"><path fill="currentColor" d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"></path></svg>
-              Sign in with Google
+              Entrar com Google
             </Button>
             <p className="px-8 text-center text-sm text-muted-foreground flex items-center justify-center">
-              <Lock className="h-4 w-4 mr-2" /> Secure Login via Google OAuth
+              <Lock className="h-4 w-4 mr-2" /> Login Seguro via Google OAuth
             </p>
           </div>
         </CardContent>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -36,10 +36,10 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
-  { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard, tooltip: "Dashboard" },
-  { href: '/calendar', label: 'Calendar', icon: CalendarDays, tooltip: "Calendar" },
-  { href: '/patients', label: 'Patients', icon: Users, tooltip: "Patients" },
-  { href: '/settings', label: 'Settings', icon: Settings, tooltip: "Settings" },
+  { href: '/dashboard', label: 'Painel', icon: LayoutDashboard, tooltip: "Painel" },
+  { href: '/calendar', label: 'Calendário', icon: CalendarDays, tooltip: "Calendário" },
+  { href: '/patients', label: 'Pacientes', icon: Users, tooltip: "Pacientes" },
+  { href: '/settings', label: 'Configurações', icon: Settings, tooltip: "Configurações" },
 ];
 
 export function AppShell({ children }: { children: React.ReactNode }) {
@@ -91,7 +91,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <SidebarFooter className="p-4 mt-auto">
            <div className="group-data-[collapsible=icon]:hidden flex flex-col items-center text-xs text-sidebar-foreground/70">
             <p>&copy; {new Date().getFullYear()} AgendaWise</p>
-            <p>All rights reserved.</p>
+            <p>Todos os direitos reservados.</p>
           </div>
         </SidebarFooter>
       </Sidebar>
@@ -107,7 +107,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" className="relative h-10 w-10 rounded-full">
                 <Avatar className="h-9 w-9">
-                  <AvatarImage src="https://placehold.co/100x100.png" alt="User Avatar" data-ai-hint="user avatar" />
+                  <AvatarImage src="https://placehold.co/100x100.png" alt="Avatar do Usuário" data-ai-hint="user avatar" />
                   <AvatarFallback className="bg-primary text-primary-foreground">{userInitial}</AvatarFallback>
                 </Avatar>
               </Button>
@@ -115,21 +115,21 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <DropdownMenuContent className="w-56" align="end" forceMount>
               <DropdownMenuLabel className="font-normal">
                 <div className="flex flex-col space-y-1">
-                  <p className="text-sm font-medium leading-none">AgendaWise User</p>
+                  <p className="text-sm font-medium leading-none">Usuário AgendaWise</p>
                   <p className="text-xs leading-none text-muted-foreground">
-                    user@agendawise.com
+                    usuario@agendawise.com
                   </p>
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => router.push('/settings')}>
                 <Settings className="mr-2 h-4 w-4" />
-                <span>Settings</span>
+                <span>Configurações</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleLogout}>
                 <LogOut className="mr-2 h-4 w-4" />
-                <span>Log out</span>
+                <span>Sair</span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -46,7 +46,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+          <span className="sr-only">Fechar</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -67,7 +67,7 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+            <span className="sr-only">Fechar</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>


### PR DESCRIPTION
Traduz os principais textos da interface do usuário em várias páginas e componentes para o Português do Brasil.

Isso inclui:
- Página de Login
- Layout principal da aplicação (AppShell)
- Páginas de Calendário, Dashboard, Pacientes (lista, novo, detalhes, editar) e Configurações.
- Textos auxiliares em componentes de UI como Dialog e Sheet.
- Garante a formatação de data para pt-BR onde aplicável.