### PR TITLE
fix: Add missing Card component imports in admin dashboard page

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { cookies } from 'next/headers'; // Para acessar cookies em Server Components
 import StatsCard from '@/components/admin/StatsCard';
 import { Users, BriefcaseMedical, CalendarClock, DollarSign, TrendingUp, TrendingDown } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter // Importando CardFooter e outros componentes Card
+} from "@/components/ui/card";
 
 // Estrutura de dados conforme especificado
 interface DashboardStats {


### PR DESCRIPTION
Resolved a ReferenceError for CardFooter (and potentially other Card components) during build by ensuring all used Card components (Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter) are correctly imported from '@/components/ui/card' in 'src/app/admin/dashboard/page.tsx'.