### PR TITLE
debug: Temporarily comment out CardFooter in StatsCard

### DIFF
--- a/src/components/admin/StatsCard.tsx
+++ b/src/components/admin/StatsCard.tsx
@@ -46,12 +46,12 @@ export default function StatsCard({
           <p className="text-xs text-muted-foreground">{description}</p>
         )}
       </CardContent>
-      {footerText && (
+      {/* {footerText && (
         <CardFooter className="text-xs text-muted-foreground">
           {FooterIcon && <FooterIcon className={`h-4 w-4 mr-1 ${iconColorClass}`} />}
           {footerText}
         </CardFooter>
-      )}
+      )} */}
     </Card>
   );
 }


### PR DESCRIPTION
To isolate the 'ReferenceError: CardFooter is not defined' error during build, this commit temporarily comments out the CardFooter section within the StatsCard component. This will help determine if the issue originates from this specific usage.