### PR TITLE
docs: Adicionar documentação para login e painel de administração

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,11 +27,14 @@ Para facilitar a navegação, a documentação está organizada nas seguintes se
     *   [Genkit (Funcionalidades de IA)](./api-integration/genkit.md)
 6.  **[Gerenciamento de Estado](./state-management/overview.md)**
     *   [Visão Geral (NextAuth.js para Sessão)](./state-management/overview.md)
-7.  **[Estilo e Tematização](./styling/tailwind.md)**
+7.  **[Autenticação e Painel Admin](./admin-auth/login.md)**
+    *   [Tela de Login Administrativo](./admin-auth/login.md)
+    *   [Layout do Painel de Administração](./admin-auth/admin-panel.md)
+8.  **[Estilo e Tematização](./styling/tailwind.md)**
     *   [Tailwind CSS](./styling/tailwind.md)
-8.  **[Deployment](./deployment/apphosting.md)**
+9.  **[Deployment](./deployment/apphosting.md)**
     *   [Firebase App Hosting](./deployment/apphosting.md)
-9.  **[Troubleshooting](./troubleshooting/common-issues.md)**
+10. **[Troubleshooting](./troubleshooting/common-issues.md)**
     *   [Problemas Comuns e Soluções](./troubleshooting/common-issues.md)
 
 ## Como Usar esta Documentação com uma IA

--- a/docs/admin-auth/admin-panel.md
+++ b/docs/admin-auth/admin-panel.md
@@ -1,0 +1,121 @@
+# Documentação do Layout do Painel de Administração
+
+Este documento descreve a estrutura e o funcionamento do layout principal do painel de administração da Deep Saúde Plataforma, definido em `src/app/admin/layout.tsx`.
+
+## Visão Geral
+
+O `AdminLayout` é um componente React que envolve todas as páginas da seção administrativa (`/admin/*`). Ele fornece uma estrutura consistente contendo uma barra lateral de navegação (sidebar) e um cabeçalho (header), além de gerenciar o estado visual desses componentes, como o colapso da sidebar.
+
+## Estrutura do Arquivo
+
+O componente principal é `AdminLayout`, localizado em `src/app/admin/layout.tsx`. Ele é um Client Component (`"use client";`) para permitir o uso de `React.useState` para gerenciar o estado da sidebar.
+
+## Componentes Chave do Layout
+
+Detalhes sobre os componentes `AdminSidebar` e `AdminHeader` são cruciais para entender o painel.
+
+1.  **`AdminSidebar` (`src/components/admin/AdminSidebar.tsx`):**
+    *   **Propósito:** Exibe os links de navegação principais e secundários da seção administrativa.
+    *   **Estado:**
+        *   Recebe a prop `isCollapsed` (boolean, default `false`) do `AdminLayout` para controlar a exibição desktop (expandida ou apenas ícones).
+        *   Usa `data-collapsed={isCollapsed}` para estilização condicional.
+        *   Largura: `w-64` (expandida) ou `w-14` (colapsada, `3.5rem`).
+    *   **Estrutura:**
+        *   Logo/Título: "Deep Saúde" com ícone `Building`. Visível quando expandida.
+        *   Links de Navegação (`mainNavLinks`, `secondaryNavLinks`):
+            *   Arrays de objetos `NavLinkItem` (href, label, icon).
+            *   Renderizados usando um subcomponente `NavLink`.
+            *   `NavLink` usa `TooltipProvider`, `Tooltip`, `TooltipTrigger`, `TooltipContent` da Shadcn/UI para mostrar o `label` quando a sidebar está colapsada.
+            *   O estado ativo (`isActive`) do link é determinado por `usePathname()` e estilizado de acordo (variante `default` ou `ghost` do `Button`).
+        *   Botão de Logout: Ícone `LogOut`, com texto "Sair" quando expandida. Atualmente, executa um `alert`.
+    *   **Responsividade (Conteúdo para Mobile - `AdminSidebarSheetContent`):**
+        *   Exporta uma função `AdminSidebarSheetContent` que renderiza uma versão simplificada da sidebar, sempre expandida, para ser usada dentro do `Sheet` (menu off-canvas) no `AdminHeader` em telas mobile.
+        *   Esta versão não usa tooltips e renderiza os links diretamente com ícones e texto.
+    *   **Ícones:** Utiliza ícones de `lucide-react` (Home, Users, CalendarDays, DollarSign, BriefcaseMedical, Settings, LogOut, Building).
+    *   **Estilo:** Classes `cn` para merging de classes Tailwind CSS, `buttonVariants` para estilizar links como botões.
+
+2.  **`AdminHeader` (`src/components/admin/AdminHeader.tsx`):**
+    *   **Propósito:** Cabeçalho da área administrativa, contendo navegação mobile, breadcrumbs (placeholder), seletor de tema e menu do usuário.
+    *   **Posicionamento:**
+        *   `sticky top-0 z-30`: Fixo no topo da viewport.
+        *   Em telas `sm` e maiores: `sm:static sm:h-auto sm:border-0 sm:bg-transparent`, tornando-se parte do fluxo normal da página sem fundo ou borda própria, integrando-se visualmente com o conteúdo abaixo.
+    *   **Componentes e Funcionalidades:**
+        *   **Mobile Sidebar Toggle (`Sheet`):**
+            *   Visível apenas em telas menores que `sm` (`sm:hidden`).
+            *   Usa `Sheet`, `SheetTrigger` (com ícone `PanelLeft`), e `SheetContent` da Shadcn/UI.
+            *   O `SheetContent` renderiza o `AdminSidebarSheetContent` importado de `AdminSidebar.tsx`.
+            *   A prop `onDrawerToggle` (opcional) pode ser usada para comunicar o estado do drawer/sheet ao layout pai, se necessário.
+        *   **Breadcrumbs (`BreadcrumbsPlaceholder`):**
+            *   Atualmente um placeholder que mostra "Admin / Dashboard".
+            *   Destinado a ser uma navegação mais dinâmica baseada na rota atual.
+        *   **Theme Toggle (`ThemeToggle`):**
+            *   Componente (`src/components/admin/ThemeToggle.tsx`) para alternar entre temas claro e escuro. (Detalhes deste componente não estão no escopo deste arquivo, mas sua presença é notada).
+        *   **User Menu (`DropdownMenu`):**
+            *   Usa `DropdownMenu`, `DropdownMenuTrigger` (com ícone `UserCircle`), `DropdownMenuContent`, etc., da Shadcn/UI.
+            *   Itens de menu: "Minha Conta" (label), "Configurações", "Suporte", "Sair".
+            *   As ações dos itens de menu são placeholders.
+        *   **Busca (Comentada):**
+            *   Há código comentado para um campo de busca com ícone `Search` e `Input`.
+    *   **Estilo:** Layout flex, `border-b bg-background` para o estado fixo, `px-4 sm:px-6` para padding.
+
+## Funcionalidades do Layout (`src/app/admin/layout.tsx`)
+
+1.  **Estado da Sidebar Colapsável (Desktop):**
+    *   O `AdminLayout` utiliza `React.useState` para gerenciar o estado `isSidebarCollapsed` (inicialmente `false`, ou seja, expandida).
+    *   A função `toggleSidebar` (atualmente não conectada a nenhum controle no `AdminHeader` no código fornecido no plano, mas presente) permite alternar este estado.
+    *   A classe CSS `md:ml-${isSidebarCollapsed ? '14' : '64'}` no `div` que envolve o conteúdo principal (`<main>`) ajusta a margem esquerda do conteúdo para acomodar a sidebar expandida (`ml-64`, que geralmente corresponde a `16rem` ou `256px`) ou colapsada (`ml-14`, que geralmente corresponde a `3.5rem` ou `56px`). Isso sugere que a sidebar colapsada tem `56px` de largura e a expandida `256px`.
+    *   A `AdminSidebar` recebe `isCollapsed` e adapta sua renderização interna (ex: mostrando apenas ícones quando `isCollapsed={true}`).
+
+2.  **Estrutura Responsiva:**
+    *   **Desktop (`md:` e acima):**
+        *   A `AdminSidebar` é exibida como `md:fixed md:inset-y-0 md:left-0 md:z-50 md:flex`. Isso a torna uma barra lateral fixa à esquerda.
+        *   O conteúdo principal (`div` com a classe `md:ml-...`) se ajusta dinamicamente à largura da sidebar.
+    *   **Mobile (abaixo de `md`):**
+        *   A `AdminSidebar` com `className="hidden md:fixed ..."` estará oculta por padrão em telas menores que `md` devido ao `hidden`. Um mecanismo no `AdminHeader` (geralmente um botão de menu) seria necessário para torná-la visível (provavelmente como um `Sheet` ou off-canvas).
+        *   O `AdminHeader` é provavelmente fixo no topo, e o `main` tem `mt-14` para evitar sobreposição.
+
+3.  **Estilo e Tema:**
+    *   O `div` raiz do layout tem a classe `flex min-h-screen w-full flex-col bg-muted/40`, definindo um layout flexível vertical que ocupa toda a altura da tela, com uma cor de fundo específica (`bg-muted/40` do Tailwind/Shadcn).
+    *   O `ThemeProvider` mencionado nos comentários do arquivo original foi movido para o layout raiz (`src/app/layout.tsx`), o que é uma prática comum para garantir que o tema seja aplicado globalmente. O `AdminLayout` herda esse tema.
+
+4.  **Conteúdo Principal (`<main>`):**
+    *   O elemento `<main>` é onde o conteúdo específico de cada página administrativa (`children`) é renderizado.
+    *   Possui classes para preenchimento (`p-4 sm:px-6 sm:py-0`), espaçamento (`gap-4 md:gap-8`) e margem superior em mobile (`mt-14 md:mt-0`).
+
+## Interação entre Componentes
+
+*   `AdminLayout` (Pai):
+    *   Gerencia o estado `isSidebarCollapsed`.
+    *   Passa `isSidebarCollapsed` para `AdminSidebar`.
+    *   (Potencialmente) passaria `toggleSidebar` e `isSidebarCollapsed` para `AdminHeader` se um controle de colapso no header fosse desejado.
+*   `AdminSidebar` (Filho):
+    *   Renderiza-se de forma diferente com base na prop `isSidebarCollapsed`.
+*   `AdminHeader` (Filho):
+    *   (Potencialmente) conteria um botão para acionar a sidebar em mobile.
+    *   (Potencialmente) conteria um botão para chamar `toggleSidebar` em desktop.
+
+## Exemplo de Fluxo de Renderização
+
+1.  Usuário navega para `/admin/dashboard`.
+2.  Next.js identifica que esta rota está sob o `AdminLayout`.
+3.  `AdminLayout` é renderizado:
+    *   `AdminSidebar` é renderizada (fixa à esquerda em desktop, inicialmente expandida).
+    *   `AdminHeader` é renderizado no topo.
+    *   O conteúdo da página `/admin/dashboard` é renderizado dentro do elemento `<main>`.
+4.  Se o usuário (em desktop) clicasse em um hipotético botão de "colapsar sidebar" no `AdminHeader` (que chamaria `toggleSidebar`):
+    *   O estado `isSidebarCollapsed` em `AdminLayout` mudaria.
+    *   `AdminLayout` re-renderizaria.
+    *   `AdminSidebar` receberia a nova prop `isSidebarCollapsed` e se ajustaria (mostrando apenas ícones, por exemplo).
+    *   O `div` do conteúdo principal ajustaria sua `md:ml-` para `md:ml-14`.
+
+## Considerações para IA
+
+Ao instruir uma IA para modificar o painel de administração:
+
+*   **Especificar o componente alvo:** Se a mudança é na sidebar, referenciar `AdminSidebar.tsx`. Se for no header, `AdminHeader.tsx`. Se for no layout geral, `AdminLayout.tsx`.
+*   **Contexto do estado `isSidebarCollapsed`:** A IA precisa entender que este estado controla a aparência da sidebar e o layout do conteúdo principal em desktops.
+*   **Responsividade:** Lembrar à IA sobre as diferentes exibições em mobile (`hidden` para sidebar desktop, header fixo) vs. desktop (sidebar fixa, header no fluxo ou fixo).
+*   **ThemeProvider:** Embora não esteja diretamente no `AdminLayout.tsx`, a IA deve saber que o tema é gerenciado globalmente.
+*   **Componentes `AdminSidebar` e `AdminHeader`:** Para modificações profundas, a IA precisará do conteúdo desses arquivos para entender suas props e estrutura interna.
+
+Este layout fornece uma base robusta e responsiva para a seção administrativa. As interações precisas da sidebar móvel e do botão de colapso da sidebar desktop dependerão das implementações detalhadas em `AdminSidebar.tsx` e `AdminHeader.tsx`.

--- a/docs/admin-auth/login.md
+++ b/docs/admin-auth/login.md
@@ -1,0 +1,108 @@
+# Documentação da Tela de Login Administrativo
+
+Este documento detalha a implementação e o funcionamento da tela de login administrativo da Deep Saúde Plataforma, localizada em `src/app/admin/login/page.tsx`.
+
+## Visão Geral
+
+A tela de login administrativo permite que usuários com credenciais de administrador acessem o painel de controle da plataforma. Ela é responsável por coletar as credenciais do usuário (email, senha e código da clínica), validá-las e autenticar o usuário para acesso às seções administrativas.
+
+## Estrutura do Arquivo
+
+O componente principal da tela de login é `AdminLoginPage`, definido em `src/app/admin/login/page.tsx`.
+
+## Tecnologias e Componentes Utilizados
+
+*   **Next.js:** Framework React para renderização no servidor e funcionalidades de roteamento.
+*   **React (Client Component):** A página é um Client Component (`"use client";`) para permitir interatividade e uso de hooks.
+*   **`react-hook-form`:** Para gerenciamento de estado do formulário e validação.
+*   **`zod`:** Para definir o schema de validação dos dados do formulário.
+*   **Server Actions:** A lógica de login é manipulada por uma Server Action (`handleLogin`).
+*   **Shadcn/UI Components:**
+    *   `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, `CardFooter`: Para estruturar visualmente o formulário de login.
+    *   `Input`: Para os campos de entrada de email, senha e código da clínica.
+    *   `Label`: Para associar rótulos aos campos de entrada.
+    *   `Button`: Para o botão de submissão e o link "Esqueceu sua senha?".
+    *   `useToast`: Para exibir notificações de sucesso ou erro.
+*   **`lucide-react`:** Para ícones (ex: `Building` no cabeçalho do card).
+*   **`next/navigation` (`useRouter`):** Para redirecionamento após o login bem-sucedido.
+
+## Fluxo de Autenticação e Lógica do Componente
+
+1.  **Schema de Validação:**
+    *   Um schema `loginFormSchema` é definido usando `zod` para validar os campos:
+        *   `email`: Deve ser um email válido.
+        *   `password`: Deve ter no mínimo 6 caracteres.
+        *   `clinicCode`: Deve ter no mínimo 3 caracteres.
+    *   O tipo `LoginFormValues` é inferido a partir deste schema.
+
+2.  **Gerenciamento de Estado do Formulário:**
+    *   `useForm` (de `react-hook-form`) é utilizado para registrar os campos, manipular a submissão e integrar com o resolver do `zod` (`zodResolver`).
+    *   `useFormState` (de `react-dom`) é usado para gerenciar o estado retornado pela Server Action `handleLogin`. Ele fornece `state` (com mensagens, erros e status de sucesso) e `formAction` (a função a ser chamada na submissão do formulário).
+    *   `useFormStatus` (de `react-dom`) é usado no componente `SubmitButton` para desabilitar o botão e mostrar um texto de "Entrando..." enquanto a submissão está pendente.
+
+3.  **Submissão do Formulário:**
+    *   O formulário (`<form>`) tem sua prop `action` definida como `formAction` (proveniente de `useFormState`).
+    *   Ao submeter, a Server Action `handleLogin` (localizada em `src/app/admin/login/actions.ts`) é invocada no servidor com os dados do formulário.
+
+4.  **Server Action (`handleLogin`):**
+    *   Localizada em `src/app/admin/login/actions.ts`.
+    *   É marcada com `"use server";` para indicar que é uma Server Action.
+    *   Recebe o estado anterior (`prevState: LoginFormState`) e os dados do formulário (`formData: FormData`) como argumentos.
+    *   **Lógica Atual (Mock):**
+        *   A implementação atual da `handleLogin` é um **mock** para simular um login bem-sucedido.
+        *   Ela não realiza validação de credenciais ou consulta a banco de dados.
+        *   Define um token de sessão falso: `mock-admin-jwt-token-para-teste-de-ui`.
+        *   Configura um cookie de sessão chamado `adminSessionToken` com o token mock. Este cookie é:
+            *   `httpOnly`: Não acessível por JavaScript no lado do cliente.
+            *   `secure`: Enviado apenas sobre HTTPS em produção.
+            *   `path: "/"`: Disponível em todo o site.
+            *   `sameSite: "lax"`: Proteção CSRF.
+            *   `maxAge: 60 * 60`: Válido por 1 hora.
+        *   Retorna um objeto `LoginFormState` com `success: true` e a mensagem "Login simulado com sucesso!".
+    *   **Lógica Esperada (Produção):**
+        *   Em um ambiente de produção, esta action deveria:
+            *   Validar os dados recebidos de `formData` (embora a validação primária ocorra no cliente com Zod, uma validação no servidor é crucial). O schema `loginSchema` presente no arquivo `actions.ts` pode ser usado para isso.
+            *   Consultar um serviço de autenticação ou banco de dados para verificar as credenciais (email, senha) e o código da clínica.
+            *   Em caso de falha, retornar `success: false` e mensagens de erro apropriadas em `message` e/ou `errors`.
+            *   Em caso de sucesso, gerar um token de sessão real e seguro, armazená-lo (ex: em um cookie `httpOnly`) e retornar `success: true`.
+    *   **Estrutura de Retorno (`LoginFormState`):**
+        *   `message: string`: Mensagem geral sobre o resultado da operação.
+        *   `errors?: { email?: string[]; password?: string[]; clinicCode?: string[]; _form?: string[]; }`: Erros específicos por campo ou erros gerais do formulário (chave `_form`).
+        *   `success: boolean`: Indica se o login foi bem-sucedido.
+
+5.  **Feedback ao Usuário e Redirecionamento:**
+    *   Um `useEffect` monitora o `state` retornado pela Server Action.
+    *   **Em caso de sucesso (`state.success === true`):**
+        *   Uma notificação de sucesso é exibida usando `toast()`.
+        *   O usuário é redirecionado para a página `/admin/dashboard` usando `router.push()`.
+    *   **Em caso de erro (`state.success === false` e `state.message` ou `state.errors` presentes):**
+        *   Uma notificação de erro é exibida usando `toast()` com `variant: "destructive"`. A mensagem de erro é extraída de `state.errors._form` ou `state.message`.
+        *   Erros específicos por campo (ex: `state.errors.email`) são exibidos abaixo dos respectivos campos de entrada.
+
+6.  **Componente `SubmitButton`:**
+    *   Este subcomponente usa `useFormStatus()` para acessar o estado `pending` da submissão do formulário pai.
+    *   O botão é desabilitado e seu texto muda para "Entrando..." quando `pending` é `true`.
+
+7.  **Interface do Usuário:**
+    *   O formulário é apresentado dentro de um componente `Card`.
+    *   O título "Login Administrativo" e uma descrição são exibidos no `CardHeader`, junto com um ícone `Building`.
+    *   Cada campo de formulário (`email`, `password`, `clinicCode`) possui um `Label` e um `Input`.
+    *   Mensagens de erro de validação específicas para cada campo são exibidas abaixo do campo correspondente se houver erros.
+    *   Um link "Esqueceu sua senha?" está presente no `CardFooter`, embora sua funcionalidade atual seja um simples `alert`.
+
+## Considerações de Segurança e Boas Práticas
+
+*   **Server Actions:** A lógica de autenticação real ocorre no servidor dentro da Server Action, o que é bom para a segurança, pois o código sensível não é exposto ao cliente.
+*   **Validação:** A validação é feita tanto no cliente (implicitamente pelo `react-hook-form` com `zod`, fornecendo feedback rápido) quanto no servidor (dentro da Server Action, que é a validação autoritativa).
+*   **HTTPS:** É crucial que a aplicação seja servida sobre HTTPS em produção para proteger as credenciais em trânsito.
+*   **Gerenciamento de Sessão:** Após o login bem-sucedido, a Server Action (ou o mecanismo de autenticação que ela usa) deve estabelecer uma sessão segura para o usuário (por exemplo, usando cookies HTTPOnly). (Este aspecto é gerenciado pelo NextAuth.js no contexto mais amplo da aplicação, mas a Server Action de login é o ponto de entrada).
+*   **Proteção contra Ataques:** Considerar medidas contra ataques de força bruta (limitação de taxa), e garantir que o código da clínica adicione uma camada de segurança ou segmentação, se aplicável.
+
+## Pontos de Extensibilidade e Melhoria
+
+*   **Funcionalidade "Esqueci minha senha":** Implementar um fluxo completo de redefinição de senha.
+*   **Autenticação de Dois Fatores (2FA):** Para maior segurança, considerar a adição de 2FA.
+*   **Internacionalização (i18n):** Se a plataforma precisar suportar múltiplos idiomas, as mensagens de erro e os textos da UI devem ser internacionalizados.
+*   **Testes:** Adicionar testes unitários e de integração para o formulário de login e a Server Action.
+
+Este documento deve fornecer uma base sólida para entender a tela de login administrativo. Para detalhes específicos sobre a lógica de negócios da autenticação, consulte o arquivo `src/app/admin/login/actions.ts`.

--- a/docs/api-integration/firebase.md
+++ b/docs/api-integration/firebase.md
@@ -13,7 +13,24 @@ O Firebase pode estar envolvido no processo de autenticação do Google da segui
 1.  **Configuração do Provedor Google no Firebase:** O projeto Firebase associado à aplicação precisa ter o provedor de login do Google ativado e configurado com as credenciais OAuth 2.0 (Client ID e Client Secret).
 2.  **Credenciais no NextAuth.js:** Essas mesmas credenciais do Google Cloud/Firebase (Client ID e Client Secret) são então usadas na configuração do provedor Google dentro do NextAuth.js (no arquivo `src/app/api/auth/[...nextauth]/route.ts`).
 
-O fluxo de login (`signIn('google')` em `src/app/page.tsx`) redireciona o usuário para a tela de login do Google. Após a autenticação bem-sucedida, o Google redireciona de volta para a aplicação com um código ou token, que o NextAuth.js usa para estabelecer uma sessão para o usuário.
+O fluxo de login (`signIn('google')` em `src/app/page.tsx`) redireciona o usuário para a tela de login do Google. Após a autenticação bem-sucedida, o Google redireciona de volta para a aplicação com um código ou token, que o NextAuth.js usa para estabelecer uma sessão para o usuário. Este fluxo é tipicamente para usuários finais da plataforma (ex: psicólogos, pacientes).
+
+### Autenticação do Painel de Administração
+
+É importante notar que o painel de administração (`/admin/*`) utiliza um mecanismo de autenticação separado, detalhado em `docs/admin-auth/login.md`. Este sistema envolve:
+*   Uma tela de login em `src/app/admin/login/page.tsx`.
+*   Uma Server Action (`handleLogin` em `src/app/admin/login/actions.ts`) que, na sua implementação atual (mock), define um cookie de sessão chamado `adminSessionToken`.
+*   Este cookie `adminSessionToken` é o principal meio de autenticação para as rotas do painel de administração e é gerenciado independentemente das sessões do NextAuth.js.
+
+Idealmente, a Server Action `handleLogin` para administradores poderia, em uma implementação de produção, interagir com o Firebase Authentication para verificar as credenciais do administrador e gerar um token seguro que seria então usado para criar o `adminSessionToken`. No entanto, o fluxo atual é um mock e não se integra diretamente com o Firebase Authentication nesse nível.
+
+## Gerenciamento de Sessão
+
+O NextAuth.js gerencia as sessões dos usuários autenticados via provedores como o Google, geralmente usando JSON Web Tokens (JWTs) armazenados em cookies seguros (`httpOnly`, `secure`).
+
+Para o painel de administração, a sessão é gerenciada pelo cookie `adminSessionToken` configurado pela Server Action `handleLogin`. Conforme detalhado em `docs/admin-auth/login.md`, este cookie também é configurado com atributos de segurança: `httpOnly`, `secure` (em produção), `path: "/"`, `sameSite: "lax"`, e `maxAge`.
+
+Ambos os mecanismos de sessão devem ser cuidadosamente gerenciados para garantir a segurança da aplicação.
 
 ## Configuração do Firebase no Projeto
 


### PR DESCRIPTION
Cria nova documentação técnica detalhada para a tela de login administrativo e o layout do painel de administração.

- Adiciona `docs/admin-auth/login.md` descrevendo o fluxo de autenticação da tela de login, componentes utilizados, Server Action `handleLogin` (incluindo o mock atual e a lógica de produção esperada) e o gerenciamento de cookies de sessão.
- Adiciona `docs/admin-auth/admin-panel.md` detalhando os componentes `AdminLayout`, `AdminSidebar` e `AdminHeader`, incluindo suas props, estado, responsividade e interações.
- Atualiza `docs/README.md` para incluir a nova seção "Autenticação e Painel Admin" no índice.
- Ajusta `docs/api-integration/firebase.md` para diferenciar a autenticação do painel de administração (via `adminSessionToken`) da autenticação principal via NextAuth.js, e para abordar o gerenciamento de sessão em ambos os contextos.

Esta documentação visa fornecer um entendimento técnico profundo, especialmente útil para colaboração com IAs na manutenção e desenvolvimento futuro.